### PR TITLE
[Fix] DeepSeek EP accuracy issue on B200 GPUs

### DIFF
--- a/python/sglang/srt/layers/quantization/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/quantization/deep_gemm_wrapper/compile_utils.py
@@ -44,6 +44,10 @@ def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
     global _DO_COMPILE_ALL
     global _IS_FIRST_RANK_ON_NODE
 
+    # Update UE8M0 scaling configuration based on server args
+    from sglang.srt.layers.quantization.deep_gemm_wrapper.configurer import update_deepgemm_scale_ue8m0
+    update_deepgemm_scale_ue8m0(server_args.disable_deepgemm_ue8m0)
+
     # Generate m_max
     m_max = 1024 * 16
     if server_args.chunked_prefill_size < 1:

--- a/python/sglang/srt/layers/quantization/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/quantization/deep_gemm_wrapper/configurer.py
@@ -29,4 +29,17 @@ def _is_blackwell_arch() -> bool:
 ENABLE_JIT_DEEPGEMM = _compute_enable_deep_gemm()
 
 DEEPGEMM_BLACKWELL = ENABLE_JIT_DEEPGEMM and _is_blackwell_arch()
-DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL
+# Allow disabling UE8M0 scaling for accuracy-critical workloads
+# This can help with DeepSeek EP accuracy issues on B200 GPUs
+# Will be updated by server args in update_deepgemm_scale_ue8m0()
+DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL and get_bool_env_var("SGL_ENABLE_DEEPGEMM_UE8M0", default="true")
+
+
+def update_deepgemm_scale_ue8m0(disable_ue8m0: bool):
+    """Update DEEPGEMM_SCALE_UE8M0 based on server arguments."""
+    global DEEPGEMM_SCALE_UE8M0
+    if disable_ue8m0:
+        DEEPGEMM_SCALE_UE8M0 = False
+        logger.info("DeepGEMM UE8M0 scaling disabled via server argument")
+    else:
+        DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL and get_bool_env_var("SGL_ENABLE_DEEPGEMM_UE8M0", default="true")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -268,6 +268,7 @@ class ServerArgs:
     flashinfer_mxfp4_moe_precision: Literal["default", "bf16"] = "default"
     enable_flashinfer_allreduce_fusion: bool = False
     deepep_mode: Literal["auto", "normal", "low_latency"] = "auto"
+    disable_deepgemm_ue8m0: bool = False
     ep_num_redundant_experts: int = 0
     ep_dispatch_algorithm: Optional[Literal["static", "dynamic", "fake"]] = None
     init_expert_location: str = "trivial"
@@ -1561,6 +1562,11 @@ class ServerArgs:
             choices=["normal", "low_latency", "auto"],
             default="auto",
             help="Select the mode when enable DeepEP MoE, could be `normal`, `low_latency` or `auto`. Default is `auto`, which means `low_latency` for decode batch and `normal` for prefill batch.",
+        )
+        parser.add_argument(
+            "--disable-deepgemm-ue8m0",
+            action="store_true",
+            help="Disable DeepGEMM UE8M0 scaling optimizations. This can help with accuracy issues on Blackwell GPUs (B200) for certain models like DeepSeek.",
         )
         parser.add_argument(
             "--ep-num-redundant-experts",


### PR DESCRIPTION
## Problem

DeepSeek models with expert parallelism (EP) experience accuracy issues on NVIDIA B200 GPUs while working correctly on H200 GPUs. This affects GSM8K benchmark and other accuracy-sensitive workloads.

**Affected Configuration:**
```bash
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-V3-0324 --tp-size 8 --ep-size 8 --trust-remote-code
python3 benchmark/gsm8k/bench_sglang.py
```

**Symptoms:**
- ✅ Works correctly on H200 GPUs (SM90 architecture)
- ❌ Produces incorrect results on B200 GPUs (SM100 Blackwell architecture)
- No error messages, but accuracy degradation in model outputs

## Root Cause

The issue is caused by Blackwell-specific optimizations in the DeepEP dispatcher:

1. **Architecture Detection**: B200 GPUs are automatically detected as Blackwell architecture (SM100)
2. **UE8M0 Scaling**: Blackwell-specific UE8M0 FP8 scaling optimizations are automatically enabled
3. **Accuracy Impact**: These optimizations prioritize performance over numerical precision, causing accuracy degradation

## Solution

Add a new server argument `--disable-deepgemm-ue8m0` to disable Blackwell-specific optimizations when accuracy is critical.

### Changes Made

1. **Server Argument**: Added `--disable-deepgemm-ue8m0` flag in `server_args.py`
2. **Configuration Function**: Added `update_deepgemm_scale_ue8m0()` in `configurer.py` to control UE8M0
3. **Integration**: Connected server args to DeepGEMM configuration in `compile_utils.py`

### Usage

**For B200 GPUs (with accuracy fix):**
```bash
python3 -m sglang.launch_server \
    --model deepseek-ai/DeepSeek-V3-0324 \
    --tp-size 8 --ep-size 8 \
    --trust-remote-code \
    --disable-deepgemm-ue8m0
```

**For H200 GPUs (no change needed):**
```bash
python3 -m sglang.launch_server \
    --model deepseek-ai/DeepSeek-V3-0324 \
    --tp-size 8 --ep-size 8 \
    --trust-remote-code
```
